### PR TITLE
Programmatically read player name from Battlefield2 game files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,12 @@ $tf/
 # Guidance Automation Toolkit
 *.gpState
 
-# ReSharper is a .NET coding add-in
+# JetBrains Rider is a .NET coding IDE
+/.idea/*
+.idea/
+*.sln.iml
+
+# JetBrains ReSharper is a .NET coding add-in
 _ReSharper*/
 *.[Rr]e[Ss]harper
 *.DotSettings.user

--- a/Battlefield rich presence/Api.cs
+++ b/Battlefield rich presence/Api.cs
@@ -21,10 +21,11 @@ namespace BattlefieldRichPresence
             return jsonSerializer.Deserialize<ServerInfo>(data);
         }
 
-        public static ServerInfo OldTitleServerInfo(Config config, string gameName)
+        public static ServerInfo OldTitleServerInfo(string unescapedPlayerName, string gameName)
         {
             WebClient webClient = new WebClient();
-            string data = webClient.DownloadString(new Uri($"https://api.bflist.io/{gameName}/v1/players/{Uri.EscapeDataString((string)config.PlayerNames[gameName])}/server"));
+            string playerName = Uri.EscapeDataString(unescapedPlayerName);
+            string data = webClient.DownloadString(new Uri($"https://api.bflist.io/{gameName}/v1/players/{playerName}/server"));
             JavaScriptSerializer jsonSerializer = new JavaScriptSerializer();
             return jsonSerializer.Deserialize<ServerInfo>(data);
         }

--- a/Battlefield rich presence/App.config
+++ b/Battlefield rich presence/App.config
@@ -24,9 +24,6 @@
             <setting name="bfvietnam" serializeAs="String">
                 <value />
             </setting>
-            <setting name="bf2" serializeAs="String">
-                <value />
-            </setting>
             <setting name="bf2142" serializeAs="String">
                 <value />
             </setting>

--- a/Battlefield rich presence/Battlefield rich presence.csproj
+++ b/Battlefield rich presence/Battlefield rich presence.csproj
@@ -80,6 +80,10 @@
     <Reference Include="DiscordRPC, Version=1.0.175.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
     </Reference>
+    <Reference Include="GameDataReader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\packages\GameDataReader.0.0.1\lib\netstandard2.0\GameDataReader.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>

--- a/Battlefield rich presence/Battlefield rich presence.csproj
+++ b/Battlefield rich presence/Battlefield rich presence.csproj
@@ -81,7 +81,7 @@
       <HintPath>..\packages\DiscordRichPresence.1.0.175\lib\net35\DiscordRPC.dll</HintPath>
     </Reference>
     <Reference Include="GameDataReader, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\packages\GameDataReader.0.0.1\lib\netstandard2.0\GameDataReader.dll</HintPath>
+      <HintPath>..\packages\GameDataReader.0.0.2\lib\netstandard2.0\GameDataReader.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Battlefield rich presence/Config.cs
+++ b/Battlefield rich presence/Config.cs
@@ -21,7 +21,6 @@ namespace BattlefieldRichPresence
             {
                 Bf1942 = Settings.Default.bf1942,
                 Bfvietnam = Settings.Default.bfvietnam,
-                Bf2 = Settings.Default.bf2,
                 Bf2142 = Settings.Default.bf2142,
                 Bfbc2 = Settings.Default.bfbc2,
                 Bf3 = Settings.Default.bf3,
@@ -34,7 +33,6 @@ namespace BattlefieldRichPresence
         {
             Settings.Default.bf1942 = PlayerNames.Bf1942;
             Settings.Default.bfvietnam = PlayerNames.Bfvietnam;
-            Settings.Default.bf2 = PlayerNames.Bf2;
             Settings.Default.bf2142 = PlayerNames.Bf2142;
             Settings.Default.bfbc2 = PlayerNames.Bfbc2;
             Settings.Default.bf3 = PlayerNames.Bf3;

--- a/Battlefield rich presence/DiscordPresence.cs
+++ b/Battlefield rich presence/DiscordPresence.cs
@@ -148,7 +148,8 @@ namespace BattlefieldRichPresence
             {
                 try
                 {
-                    ServerInfo serverInfo = Api.OldTitleServerInfo(_config, gameInfo.ShortName);
+                    var playerName = (string)_config.PlayerNames[gameInfo.ShortName];
+                    ServerInfo serverInfo = Api.OldTitleServerInfo(playerName, gameInfo.ShortName);
                     UpdatePresence(gameInfo, serverInfo);
                 }
                 catch (Exception)

--- a/Battlefield rich presence/DiscordPresence.cs
+++ b/Battlefield rich presence/DiscordPresence.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Threading;
 using BattlefieldRichPresence.ChangePrensence;
 using BattlefieldRichPresence.GameReader;
 using BattlefieldRichPresence.Resources;
 using BattlefieldRichPresence.Structs;
 using DiscordRPC;
+using GameDataReader;
 
 namespace BattlefieldRichPresence
 {
@@ -142,6 +142,19 @@ namespace BattlefieldRichPresence
                     {
                         UpdatePresenceInMenu(gameInfo);
                     }
+                }
+            }
+            else if (gameInfo.IsRunning && gameInfo.Game == Statics.Game.Bf2)
+            {
+                try
+                {
+                    var playerName = GameDataReaders.Bf2.ReadActivePlayer().OnlineName;
+                    ServerInfo serverInfo = Api.OldTitleServerInfo(playerName, gameInfo.ShortName);
+                    UpdatePresence(gameInfo, serverInfo);
+                }
+                catch (Exception)
+                {
+                    UpdatePresenceInMenu(gameInfo);
                 }
             }
             else if (gameInfo.IsRunning && (string)_config.PlayerNames[gameInfo.ShortName] != null)

--- a/Battlefield rich presence/EditWindow.Designer.cs
+++ b/Battlefield rich presence/EditWindow.Designer.cs
@@ -33,35 +33,42 @@ namespace BattlefieldRichPresence
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(EditWindow));
             this.PlayerNameBox = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
+            this.LabelInfoText = new System.Windows.Forms.Label();
             this.SaveButton = new System.Windows.Forms.Button();
             this.GameSelector = new System.Windows.Forms.ComboBox();
             this.ChangeAllButton = new System.Windows.Forms.Button();
+            this.LabelGameSelector = new System.Windows.Forms.Label();
+            this.LabelPlayerNameBox = new System.Windows.Forms.Label();
+            this.GroupBoxPlayerName = new System.Windows.Forms.GroupBox();
+            this.LabelInfoIcon = new System.Windows.Forms.Label();
+            this.GroupBoxPlayerName.SuspendLayout();
             this.SuspendLayout();
             // 
             // PlayerNameBox
             // 
-            this.PlayerNameBox.Location = new System.Drawing.Point(139, 41);
+            this.PlayerNameBox.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.PlayerNameBox.Location = new System.Drawing.Point(88, 103);
             this.PlayerNameBox.Name = "PlayerNameBox";
-            this.PlayerNameBox.Size = new System.Drawing.Size(154, 20);
+            this.PlayerNameBox.Size = new System.Drawing.Size(248, 25);
             this.PlayerNameBox.TabIndex = 0;
             this.PlayerNameBox.TextChanged += new System.EventHandler(this.PlayerNameBox_TextChanged);
             // 
-            // label2
+            // LabelInfoText
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(9, 10);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(271, 26);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "If you are playing Battlefield titles older than Battlefield 1,\nfill in your in g" +
-    "ame name (without prefix/clan tag)";
+            this.LabelInfoText.AutoSize = true;
+            this.LabelInfoText.Font = new System.Drawing.Font("Segoe UI Light", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.LabelInfoText.Location = new System.Drawing.Point(61, 36);
+            this.LabelInfoText.Name = "LabelInfoText";
+            this.LabelInfoText.Size = new System.Drawing.Size(286, 15);
+            this.LabelInfoText.TabIndex = 2;
+            this.LabelInfoText.Text = "Games not in the list support automatic name detection";
             // 
             // SaveButton
             // 
-            this.SaveButton.Location = new System.Drawing.Point(299, 40);
+            this.SaveButton.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.SaveButton.Location = new System.Drawing.Point(156, 179);
             this.SaveButton.Name = "SaveButton";
-            this.SaveButton.Size = new System.Drawing.Size(75, 22);
+            this.SaveButton.Size = new System.Drawing.Size(247, 32);
             this.SaveButton.TabIndex = 3;
             this.SaveButton.Text = "Save";
             this.SaveButton.UseVisualStyleBackColor = true;
@@ -69,47 +76,100 @@ namespace BattlefieldRichPresence
             // 
             // GameSelector
             // 
+            this.GameSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.GameSelector.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.GameSelector.FormattingEnabled = true;
-            this.GameSelector.Location = new System.Drawing.Point(12, 41);
+            this.GameSelector.Location = new System.Drawing.Point(88, 69);
             this.GameSelector.Name = "GameSelector";
-            this.GameSelector.Size = new System.Drawing.Size(121, 21);
+            this.GameSelector.Size = new System.Drawing.Size(248, 25);
             this.GameSelector.TabIndex = 4;
             this.GameSelector.SelectedIndexChanged += new System.EventHandler(this.GameSelector_SelectedIndexChanged);
             // 
             // ChangeAllButton
             // 
-            this.ChangeAllButton.Location = new System.Drawing.Point(379, 40);
+            this.ChangeAllButton.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.ChangeAllButton.Location = new System.Drawing.Point(21, 179);
             this.ChangeAllButton.Name = "ChangeAllButton";
-            this.ChangeAllButton.Size = new System.Drawing.Size(75, 22);
+            this.ChangeAllButton.Size = new System.Drawing.Size(129, 32);
             this.ChangeAllButton.TabIndex = 5;
-            this.ChangeAllButton.Text = "Change all";
+            this.ChangeAllButton.Text = "Save for all games";
             this.ChangeAllButton.UseVisualStyleBackColor = true;
             this.ChangeAllButton.Click += new System.EventHandler(this.ChangeAllButton_Click);
+            // 
+            // LabelGameSelector
+            // 
+            this.LabelGameSelector.AutoSize = true;
+            this.LabelGameSelector.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.LabelGameSelector.Location = new System.Drawing.Point(38, 74);
+            this.LabelGameSelector.Name = "LabelGameSelector";
+            this.LabelGameSelector.Size = new System.Drawing.Size(41, 15);
+            this.LabelGameSelector.TabIndex = 6;
+            this.LabelGameSelector.Text = "Game:";
+            // 
+            // LabelPlayerNameBox
+            // 
+            this.LabelPlayerNameBox.AutoSize = true;
+            this.LabelPlayerNameBox.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.LabelPlayerNameBox.Location = new System.Drawing.Point(37, 107);
+            this.LabelPlayerNameBox.Name = "LabelPlayerNameBox";
+            this.LabelPlayerNameBox.Size = new System.Drawing.Size(42, 15);
+            this.LabelPlayerNameBox.TabIndex = 7;
+            this.LabelPlayerNameBox.Text = "Name:";
+            // 
+            // GroupBoxPlayerName
+            // 
+            this.GroupBoxPlayerName.Controls.Add(this.LabelInfoText);
+            this.GroupBoxPlayerName.Controls.Add(this.LabelInfoIcon);
+            this.GroupBoxPlayerName.Controls.Add(this.LabelPlayerNameBox);
+            this.GroupBoxPlayerName.Controls.Add(this.PlayerNameBox);
+            this.GroupBoxPlayerName.Controls.Add(this.LabelGameSelector);
+            this.GroupBoxPlayerName.Controls.Add(this.GameSelector);
+            this.GroupBoxPlayerName.Font = new System.Drawing.Font("Segoe UI", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.GroupBoxPlayerName.Location = new System.Drawing.Point(21, 17);
+            this.GroupBoxPlayerName.Name = "GroupBoxPlayerName";
+            this.GroupBoxPlayerName.Size = new System.Drawing.Size(382, 153);
+            this.GroupBoxPlayerName.TabIndex = 8;
+            this.GroupBoxPlayerName.TabStop = false;
+            this.GroupBoxPlayerName.Text = "Configure in-game name (without prefix/clan tag)";
+            // 
+            // LabelInfoIcon
+            // 
+            this.LabelInfoIcon.AutoSize = true;
+            this.LabelInfoIcon.Font = new System.Drawing.Font("Segoe UI Emoji", 11.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.LabelInfoIcon.Location = new System.Drawing.Point(35, 33);
+            this.LabelInfoIcon.Name = "LabelInfoIcon";
+            this.LabelInfoIcon.Size = new System.Drawing.Size(30, 20);
+            this.LabelInfoIcon.TabIndex = 8;
+            this.LabelInfoIcon.Text = "ℹ";
             // 
             // EditWindow
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(466, 73);
+            this.ClientSize = new System.Drawing.Size(423, 226);
+            this.Controls.Add(this.GroupBoxPlayerName);
             this.Controls.Add(this.ChangeAllButton);
-            this.Controls.Add(this.GameSelector);
             this.Controls.Add(this.SaveButton);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.PlayerNameBox);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MaximizeBox = false;
             this.Name = "EditWindow";
             this.Text = "Edit settings";
+            this.GroupBoxPlayerName.ResumeLayout(false);
+            this.GroupBoxPlayerName.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
 
         private TextBox PlayerNameBox;
-        private Label label2;
+        private Label LabelInfoText;
         private Button SaveButton;
         private ComboBox GameSelector;
         private Button ChangeAllButton;
+        private Label LabelGameSelector;
+        private Label LabelPlayerNameBox;
+        private GroupBox GroupBoxPlayerName;
+        private Label LabelInfoIcon;
     }
 }

--- a/Battlefield rich presence/EditWindow.cs
+++ b/Battlefield rich presence/EditWindow.cs
@@ -65,12 +65,14 @@ namespace BattlefieldRichPresence
             Save();
             SaveButton.Text = "Saved!";
             await Task.Delay(1000);
-            SaveButton.Text = "Save";
+            SaveButton.Text = $"Save for {GameSelector.SelectedItem}";
         }
 
         private void GameSelector_SelectedIndexChanged(object sender, EventArgs e)
         {
-            string playerName = (string)_current[GameSelector.SelectedItem.ToString()];
+            var gameName = GameSelector.SelectedItem.ToString();
+            SaveButton.Text = $"Save for {GameSelector.SelectedItem}";
+            string playerName = (string)_current[gameName];
             PlayerNameBox.Text = playerName ?? "";
         }
 

--- a/Battlefield rich presence/EditWindow.cs
+++ b/Battlefield rich presence/EditWindow.cs
@@ -26,7 +26,6 @@ namespace BattlefieldRichPresence
             {
                 Bf1942 = PlayerNames.Bf1942,
                 Bfvietnam = PlayerNames.Bfvietnam,
-                Bf2 = PlayerNames.Bf2,
                 Bf2142 = PlayerNames.Bf2142,
                 Bfbc2 = PlayerNames.Bfbc2,
                 Bf3 = PlayerNames.Bf3,

--- a/Battlefield rich presence/Properties/Settings.Designer.cs
+++ b/Battlefield rich presence/Properties/Settings.Designer.cs
@@ -50,18 +50,6 @@ namespace BattlefieldRichPresence.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("")]
-        public string bf2 {
-            get {
-                return ((string)(this["bf2"]));
-            }
-            set {
-                this["bf2"] = value;
-            }
-        }
-        
-        [global::System.Configuration.UserScopedSettingAttribute()]
-        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("")]
         public string bf2142 {
             get {
                 return ((string)(this["bf2142"]));

--- a/Battlefield rich presence/Properties/Settings.settings
+++ b/Battlefield rich presence/Properties/Settings.settings
@@ -8,9 +8,6 @@
     <Setting Name="bfvietnam" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
-    <Setting Name="bf2" Type="System.String" Scope="User">
-      <Value Profile="(Default)" />
-    </Setting>
     <Setting Name="bf2142" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>

--- a/Battlefield rich presence/Resources/Statics.cs
+++ b/Battlefield rich presence/Resources/Statics.cs
@@ -47,7 +47,6 @@ namespace BattlefieldRichPresence.Resources
         {
             Game.Bf1942,
             Game.Bfvietnam,
-            Game.Bf2,
             Game.Bf2142,
             Game.Bfbc2,
             Game.Bf3,

--- a/Battlefield rich presence/Structs/GamesPlayerName.cs
+++ b/Battlefield rich presence/Structs/GamesPlayerName.cs
@@ -7,7 +7,6 @@ namespace BattlefieldRichPresence.Structs
     {
         public string Bf1942 { get; set; }
         public string Bfvietnam { get; set; }
-        public string Bf2 { get; set; }
         public string Bf2142 { get; set; }
         public string Bfbc2 { get; set; }
         public string Bf3 { get; set; }

--- a/Battlefield rich presence/packages.config
+++ b/Battlefield rich presence/packages.config
@@ -3,6 +3,7 @@
   <package id="Costura.Fody" version="5.7.0" targetFramework="net48" developmentDependency="true" />
   <package id="DiscordRichPresence" version="1.0.175" targetFramework="net48" />
   <package id="Fody" version="6.5.5" targetFramework="net48" developmentDependency="true" />
+  <package id="GameDataReader" version="0.0.1" targetFramework="net48" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net48" />

--- a/Battlefield rich presence/packages.config
+++ b/Battlefield rich presence/packages.config
@@ -3,7 +3,7 @@
   <package id="Costura.Fody" version="5.7.0" targetFramework="net48" developmentDependency="true" />
   <package id="DiscordRichPresence" version="1.0.175" targetFramework="net48" />
   <package id="Fody" version="6.5.5" targetFramework="net48" developmentDependency="true" />
-  <package id="GameDataReader" version="0.0.1" targetFramework="net48" />
+  <package id="GameDataReader" version="0.0.2" targetFramework="net48" />
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net48" />
   <package id="Microsoft.Win32.Primitives" version="4.3.0" targetFramework="net48" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net48" />


### PR DESCRIPTION
Hi! 

With these changes, users won't have to configure their BF2 name anymore, since it's being automatically read from the local `Documents\Battlefield 2` config files.

# Changes

- .gitignore local files from Rider IDE (for developers who don't use Visual Studio)
- Refactor server info query for reusability
- Extend automatic player name detection for BF2 using https://www.nuget.org/packages/GameDataReader
 	- I've created the NuGet library and will also use it in my https://bf2.tv app project - it's open-source and open for extending support of multiple games:
 	https://github.com/TwitchPlaysBF2/GameDataReader
- Remove config for BF2 player name, just like BF1 (because now it's also being programmatically detected)