### PR TITLE
BF1942 and BFV process detection and con file dynamic file path lookup

### DIFF
--- a/Battlefield rich presence/Game.cs
+++ b/Battlefield rich presence/Game.cs
@@ -14,6 +14,18 @@ namespace BattlefieldRichPresence
             Process[] processCollection = Process.GetProcesses();
             foreach (Process p in processCollection)
             {
+                if (p.ProcessName == "BF1942")
+                {
+                    Statics.Game game = (Statics.Game)Enum.Parse(typeof(Statics.Game), Statics.ShortGameName[Statics.Game.Bf1942]);
+                    return new GameInfo
+                    {
+                        Game = game,
+                        IsRunning = true,
+                        ShortName = Statics.ShortGameName[game],
+                        FullName = Statics.FullGameName[game]
+                    };
+                }
+
                 Regex rgx = new Regex(Statics.SupportedGamesRegex, RegexOptions.IgnoreCase);
                 Match match = rgx.Match(p.MainWindowTitle);
                 if (match.Success)

--- a/Battlefield rich presence/Game.cs
+++ b/Battlefield rich presence/Game.cs
@@ -8,24 +8,24 @@ namespace BattlefieldRichPresence
 {
     internal class Game
     {
-
         public static GameInfo IsRunning()
         {
+            Process[] bf1942Processes = Process.GetProcessesByName("BF1942");
+            if (bf1942Processes.Length == 1)
+            {
+                Statics.Game game = (Statics.Game)Enum.Parse(typeof(Statics.Game), Statics.ShortGameName[Statics.Game.Bf1942]);
+                return new GameInfo
+                {
+                    Game = game,
+                    IsRunning = true,
+                    ShortName = Statics.ShortGameName[game],
+                    FullName = Statics.FullGameName[game]
+                };
+            }
+
             Process[] processCollection = Process.GetProcesses();
             foreach (Process p in processCollection)
             {
-                if (p.ProcessName == "BF1942")
-                {
-                    Statics.Game game = (Statics.Game)Enum.Parse(typeof(Statics.Game), Statics.ShortGameName[Statics.Game.Bf1942]);
-                    return new GameInfo
-                    {
-                        Game = game,
-                        IsRunning = true,
-                        ShortName = Statics.ShortGameName[game],
-                        FullName = Statics.FullGameName[game]
-                    };
-                }
-
                 Regex rgx = new Regex(Statics.SupportedGamesRegex, RegexOptions.IgnoreCase);
                 Match match = rgx.Match(p.MainWindowTitle);
                 if (match.Success)

--- a/Battlefield rich presence/Game.cs
+++ b/Battlefield rich presence/Game.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Text.RegularExpressions;
 using BattlefieldRichPresence.Resources;
 using BattlefieldRichPresence.Structs;

--- a/Battlefield rich presence/Game.cs
+++ b/Battlefield rich presence/Game.cs
@@ -11,19 +11,6 @@ namespace BattlefieldRichPresence
     {
         public static GameInfo IsRunning()
         {
-            Process[] bf1942Processes = Process.GetProcessesByName("BF1942");
-            if (bf1942Processes.Any())
-            {
-                Statics.Game game = (Statics.Game)Enum.Parse(typeof(Statics.Game), Statics.ShortGameName[Statics.Game.Bf1942]);
-                return new GameInfo
-                {
-                    Game = game,
-                    IsRunning = true,
-                    ShortName = Statics.ShortGameName[game],
-                    FullName = Statics.FullGameName[game]
-                };
-            }
-
             Process[] processCollection = Process.GetProcesses();
             foreach (Process p in processCollection)
             {

--- a/Battlefield rich presence/Game.cs
+++ b/Battlefield rich presence/Game.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Text.RegularExpressions;
 using BattlefieldRichPresence.Resources;
 using BattlefieldRichPresence.Structs;
@@ -11,7 +12,7 @@ namespace BattlefieldRichPresence
         public static GameInfo IsRunning()
         {
             Process[] bf1942Processes = Process.GetProcessesByName("BF1942");
-            if (bf1942Processes.Length == 1)
+            if (bf1942Processes.Any())
             {
                 Statics.Game game = (Statics.Game)Enum.Parse(typeof(Statics.Game), Statics.ShortGameName[Statics.Game.Bf1942]);
                 return new GameInfo

--- a/Battlefield rich presence/Resources/Statics.cs
+++ b/Battlefield rich presence/Resources/Statics.cs
@@ -19,7 +19,7 @@ namespace BattlefieldRichPresence.Resources
             Bf5
         }
         // Regex group names need to match enum keys, since we need to map the matched group to an enum value 
-        public static readonly string SupportedGamesRegex = @"^(?:(?:battlefield(?:(?'Bf1'\u2122 1)|(?'Bf5'\u2122 V)|(?'Bf3' 3\u2122)|(?'Bf4' 4)|(?'Bfh' Hardline)|(?'Bfbc2': bad company 2)|(?'Bfvietnam' vietnam)))|(?:bf(?:(?'Bf2'2)|(?'Bf2142'2142)) \(v1\.[\.\-0-9]+, pid: [0-9]+\))|(?'Bf1942'bf1942 \(Ver: \w{3}, \d+ \w{3} \d+ [:0-9]+\)))$";
+        public static readonly string SupportedGamesRegex = @"^(?:(?:battlefield(?:(?'Bf1'\u2122 1)|(?'Bf5'\u2122 V)|(?'Bf3' 3\u2122)|(?'Bf4' 4)|(?'Bfh' Hardline)|(?'Bfbc2': bad company 2)|(?'Bfvietnam' vietnam)))|(?:bf(?:(?'Bf2'2)|(?'Bf2142'2142)) \(v1\.[\.\-0-9]+, pid: [0-9]+\))|(?'Bf1942'bf1942 \(Ver: \w+, \d+ \w+\.? \d+(?: [:0-9]+)?\)))$";
         public static readonly Dictionary<Game, string> ShortGameName = new Dictionary<Game, string>
         {
             { Game.Bf1942, "Bf1942" },


### PR DESCRIPTION
**Recently, I installed Battlefield Rich Presence and noticed that it did not show game info in Discord while playing BF1942 and BFV.  I cloned the repos for Battlefield Rich Presence and GameDataReader and debugged the code to figure out what was happening.**


**BF1942 had the following Battlefield Rich Presence issue that prevented game information from displaying in my profile in Discord.**

**Issue:** Battlefield Rich Presence was not able to find the BF1942 game process using a RegEx to find the running process.

**Fix:** I modified Battlefield Rich Presence to look for any processes named "BF1942" and if one match is found then a GameInfo object will be returned from the IsRunning method.

**Testing:** After the fix above was applied to Battlefield Rich Presence, I built a debug version of Battlefield Rich Presence and ran BF1942 again.  This time when BF1942 was run, Battlefield Rich Presence was displayed in my Discord profile.  However, it only displayed the "In the menus" status in my profile.  When I debugged the Battlefield Rich Presence further, I was able to determine that GameDataReader was passing back the message "Couldn't find configuration data. Is the game installed?" to Battlefield Rich Presence.  This is what led me to debug the GameDataReader code.


**BF1942 and BFV each had the GameDataReader issue below that was causing the con files for each game to not be found correctly.**

**Issue:** GameDataReader was not able to find the GeneralOptions.con and Profile.con files located within the "mods\bf1942\settings" and "Mods\BfVietnam\settings" folders in each game install folder.  GameDataReader was looking in the "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\Battlefield 1942\Mods\bf1942\settings" and "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\Battlefield Vietnam\Mods\BfVietnam\settings" folders for each game.  These folders are used when BF1942 or BFV are installed under Program Files (x86) and the game does not have permission to write to the game install folder.  However, when BF1942 or BFV is not installed under Program Files (x86) each game uses the "mods\bf1942\settings" or "Mods\BfVietnam\settings" located in that game's install folder.

**Fix:** I modified GameDataReader to dynamically lookup the path where the BF1942 or BFV processes are running from.
Those paths are then used to check if the GeneralOptions.con and Profile.con files exist within the "mods\bf1942\settings" and "Mods\BfVietnam\settings" folders in each game install folder.
If the GeneralOptions.con and Profile.con files are not found, then GameDataReader will check for the existence of the con files in the "%LOCALAPPDATA%\VirtualStore\Program Files (x86)\EA Games\" for each game.

**Testing:** After the fix above was applied to GameDataReader, I built a debug version of GameDataReader and then copied the GameDataReader DLL to the debug folder for Battlefield Rich Presence.  I then ran Battlefield Rich Presence and also launched BF1942 and connected to a multiplayer server.  Battlefield Rich Presence then correctly displayed the game and server information in my Discord profile.  I repeated the same test for BFV and Battlefield Rich Presence also displayed the game and server information in Discord.


**Note:** The fix I created for Battlefield Rich Presence is dependent upon the fix for GameDataReader.
In each program I have created my fixes in a branch called **"bf1492-bfv-fixes"**.
I have submitted pull requests on both the Battlefield Rich Presence and GameDataReader GitHub repo pages.


Below are screenshots of Battlefield Rich Presence displaying game information in Discord for Battlefield 1942 and Battlefield Vietnam.

**Battlefield 1942**
![BattlefieldRichPresence-BF1942](https://user-images.githubusercontent.com/481352/221685296-d3b1b08e-e05e-4aea-9320-9016c99bd417.jpg)

**Battlefield Vietnam**
![BattlefieldRichPresence-BFV](https://user-images.githubusercontent.com/481352/221685298-7933496f-f885-42d3-a50d-211d9e24b085.jpg)


**Hopefully, the above information has been helpful in explaining the issues that were fixed in each program.  Please let me know if more information is needed.**